### PR TITLE
chore: standardize GitHub Actions workflows

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # 6.3.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # 6.4.0
         with:
           go-version: ">=1.20.0"
       - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check broken links
-        uses: gaurav-nelson/github-action-markdown-link-check@4a1af151f4d7cf4d8f8ac5780597672a3671b88b # 1.0.17
+        uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # 1.1.2
   check-super-linter:
     runs-on: ubuntu-latest
     permissions:
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Run super-linter validation
-        uses: github/super-linter@b807e99ddd37e444d189cfd2c2ca1274d8ae8ef1 # 7
+        uses: super-linter/super-linter@9e863354e3ff62e0727d37183162c4a88873df41 # 8.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: /

--- a/.github/workflows/spell.yml
+++ b/.github/workflows/spell.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           persist-credentials: false
-      - uses: reviewdog/action-misspell@e7ea17f144822818706c7e579de7927d59384575 # 1.27.0
+      - uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # 1.27.0
         with:
           github_token: ${{ secrets.github_token }}
   check-spellcheck:


### PR DESCRIPTION
## Summary
- standardize pinned GitHub Actions versions in lint/linter, spellcheck, and update workflows
- align workflow action references with the latest owner-wide conventions
- preserve each repository's existing workflow behavior and repository-specific validations
